### PR TITLE
GCC: use -mtune=native instead of -march=native

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@
 ![ci_macos](https://github.com/gemini3d/gemini/workflows/ci_macos/badge.svg)
 
 The GEMINI model (*G*eospace *E*nvironment *M*odel of *I*on-*N*eutral *I*nteractions) is a three-dimensional ionospheric fluid-electrodynamic model used for various scientific studies including effects of auroras on the terrestrial ionosphere, natural hazard effects on the space environment, and effects of ionospheric fluid instabilities on radio propagation (see references section of this document for details).
-The detailed mathematical formulation of GEMINI is included in `doc/`.
+The detailed mathematical formulation of GEMINI is included in
+[GEMINI-docs](https://github.com/gemini3d/GEMINI-docs).
 A subroutine-level set of documentation describing functions of individual program units is given via source code comments which are
 [rendered as webpages](https://gemini3d.github.io/gemini/index.html).
 GEMINI uses generalized orthogonal curvilinear coordinates and has been tested with dipole and Cartesian coordinates.
-
 Please open a
 [GitHub Issue](https://github.com/gemini3d/gemini/issues)
 if you experience difficulty building GEMINI.
@@ -24,7 +24,7 @@ Specific commits corresponding to published results will also be noted, where ap
 ## Quickest start
 
 Gemini can run on most modern computers using Linux, MacOS, or Windows.
-Gemini even runs on the Raspberry Pi 4 with 1 GByte of RAM.
+Gemini runs on ARM CPUs including Raspberry Pi 4 with 1 GByte of RAM as well as IBM POWER CPUs.
 Windows users should use
 [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
 To build Gemini and run self-tests takes about 10 minutes on a typical laptop.

--- a/README.md
+++ b/README.md
@@ -21,12 +21,18 @@ if you experience difficulty building GEMINI.
 Generally, the Git `master` branch has the current development version and is the best place to start, while more thoroughly-tested releases happen occasionally.
 Specific commits corresponding to published results will also be noted, where appropriate, in the corresponding journal article.
 
+## Platform agnostic
+
+Gemini is OS / CPU arch / platform / compiler agnostic as much as feasible.
+Operating system support includes Linux, MacOS, or Windows.
+CPU arch support includes:
+
+* Intel / AMD
+* ARM 32 / 64 bit including Raspberry Pi 4 with 1 GByte of RAM.
+* IBM POWER
+
 ## Quickest start
 
-Gemini can run on most modern computers using Linux, MacOS, or Windows.
-Gemini runs on ARM CPUs including Raspberry Pi 4 with 1 GByte of RAM as well as IBM POWER CPUs.
-Windows users should use
-[Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
 To build Gemini and run self-tests takes about 10 minutes on a typical laptop.
 
 Requirements:

--- a/cmake/compiler_gnu.cmake
+++ b/cmake/compiler_gnu.cmake
@@ -1,4 +1,5 @@
-add_compile_options(-march=native)
+# NOTE: don't use -march=native as GCC doesn't support all CPU arches with that option.
+add_compile_options(-mtune=native)
 
 # keep Wall and Wextra in cmake_fortran_flags so FetchContent packages can override
 # and thereby avoid useless megabytes of other project warnings

--- a/cmake/h5fortran.cmake
+++ b/cmake/h5fortran.cmake
@@ -2,7 +2,7 @@ include(FetchContent)
 
 FetchContent_Declare(h5fortran_proj
   GIT_REPOSITORY https://github.com/scivision/h5fortran.git
-  GIT_TAG v2.7.1
+  GIT_TAG v2.7.2
 )
 
 FetchContent_MakeAvailable(h5fortran_proj)

--- a/scripts/compile_prereqs_ibmxl.py
+++ b/scripts/compile_prereqs_ibmxl.py
@@ -53,8 +53,8 @@ def get_compilers() -> T.Mapping[str, str]:
 
 if __name__ == "__main__":
     p = ArgumentParser()
-    p.add_argument("libs", help="libraries to compile", choices=["hdf5", "mumps"], nargs="+")
-    p.add_argument("-prefix", help="toplevel path to install libraries under", default="~/lib_intel")
+    p.add_argument("libs", help="libraries to compile", choices=["hdf5", "lapack", "scalapack", "mumps"], nargs="+")
+    p.add_argument("-prefix", help="toplevel path to install libraries under", default="~/lib_xl")
     p.add_argument("-workdir", help="toplevel path to where you keep code repos", default="~/code")
     p.add_argument("-wipe", help="wipe before completely recompiling libs", action="store_true")
     p.add_argument("-buildsys", help="build system (meson or cmake)", default="cmake")

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ scripts =
   job.py
 install_requires =
   numpy >= 1.16.0
+  scipy
   h5py
 
 [options.extras_require]


### PR DESCRIPTION
Some systems / compiler / CPU arch combinations are buggy with GCC `-march=native`. They may fail to compile or give strange runtime errors. This includes Linux Intel CPU HPC, Windows MinGW and IBM POWER.

To be more stable, we default GCC to `-mtune=native` which gives about the same performance as `-march=native` without the risks above. 

The CMake variable `CMAKE_SYSTEM_PROCESSOR` can detect CPU arch, but it's OS-dependent for the value, so we'd have to build up an `if() elseif()` if this was desired.

Also, put scipy in setup.cfg since SciPy is essential for model_setup()